### PR TITLE
Update libjxl version to 0.8.2 and fix memory allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ DEPENDENCY_SOURCE_DIRECTORY_LIBJXL := $(DEPENDENCY_SOURCE_DIRECTORY)/libjxl
 DEPENDENCY_SOURCE_URL_LIBJXL := https://github.com/libjxl/libjxl.git
 
 $(DEPENDENCY_SOURCE_DIRECTORY_LIBJXL): | $(DEPENDENCY_SOURCE_DIRECTORY)
-	git clone --depth 1 --branch v0.8.1 --recursive --shallow-submodules $(DEPENDENCY_SOURCE_URL_LIBJXL) $@
+	git clone --depth 1 --branch v0.8.2 --recursive --shallow-submodules $(DEPENDENCY_SOURCE_URL_LIBJXL) $@
 
 $(DEPENDENCY_OUTPUT_DIRECTORY)/lib/libjxl_threads.a: $(DEPENDENCY_OUTPUT_DIRECTORY)/lib/libjxl.a
 $(DEPENDENCY_OUTPUT_DIRECTORY)/lib/libhwy.a: $(DEPENDENCY_OUTPUT_DIRECTORY)/lib/libjxl.a

--- a/extractor.c
+++ b/extractor.c
@@ -203,7 +203,7 @@ int getBMPFromJXL(const uint8_t* input_data, size_t file_size,HANDLE* h_bitmap_i
 	}
 
 	// Fill in the bitmap information and file header.
-	*h_bitmap_info = LocalAlloc(LMEM_MOVEABLE | LMEM_ZEROINIT, sizeof(BITMAPINFOHEADER));
+	*h_bitmap_info = LocalAlloc(LMEM_MOVEABLE | LMEM_ZEROINIT, sizeof(BITMAPINFO));
 	if (NULL == *h_bitmap_info)
 	{
 		DBGFPRINTF(stderr, "Memory error\n");

--- a/extractor.c
+++ b/extractor.c
@@ -175,19 +175,19 @@ int getBMPFromJXL(const uint8_t* input_data, size_t file_size,HANDLE* h_bitmap_i
 	int j;
 	for (j = 0; j < height / 2; j++)
 	{
-		DWORD* cur_1 = (DWORD*)bitmap_data + j * width;
-		DWORD* cur_2 = (DWORD*)bitmap_data + (height - (1 + j)) * width;
+		DWORD* curbit_1 = (DWORD*)bitmap_data + j * width;
+		DWORD* curbit_2 = (DWORD*)bitmap_data + (height - (1 + j)) * width;
 		for (int i = 0; i < width; i++)
 		{
 			DWORD tmp =
-				((cur_1[i] << 16) & 0x00ff0000) |
-				((cur_1[i] >> 16) & 0x000000ff) |
-				((cur_1[i])       & 0xff00ff00);
-			cur_1[i] =
-				((cur_2[i] << 16) & 0x00ff0000) |
-				((cur_2[i] >> 16) & 0x000000ff) |
-				((cur_2[i])       & 0xff00ff00);
-			cur_2[i] = tmp;
+				((curbit_1[i] << 16) & 0x00ff0000) |
+				((curbit_1[i] >> 16) & 0x000000ff) |
+				((curbit_1[i])       & 0xff00ff00);
+			curbit_1[i] =
+				((curbit_2[i] << 16) & 0x00ff0000) |
+				((curbit_2[i] >> 16) & 0x000000ff) |
+				((curbit_2[i])       & 0xff00ff00);
+			curbit_2[i] = tmp;
 		}
 	}
 	if (height % 2)


### PR DESCRIPTION
1st commit : Update libjxl version to 0.8.2
2nd commit : Fix memory allocation
3rd commit : Restore variable names that have been accidentally renamed