### PR TITLE
Fix an issue where `IsSupported` occasionally returns 0 in the 64-bit version

### DIFF
--- a/spi00in.c
+++ b/spi00in.c
@@ -54,7 +54,7 @@ EXPORT(int) IsSupported(LPCSTR filename, DWORD_PTR variant)
 
 	ret = 0;
 	buffer = NULL;
-	if ((variant & 0xFFFF0000) == 0)
+	if ((variant & (DWORD_PTR)-1 - 0xFFFF) == 0)
 	{
 		buffer = malloc(header_size);
 		if (buffer == NULL)


### PR DESCRIPTION
There was an issue where the 64-bit version of the `IsSupported` function occasionally returned 0, and I have fixed it.  
The following code for the 32-bit version:

```
if ((variant & 0xFFFF0000) == 0)
```

needs to be changed to the following code for the 64-bit version:

```
if ((variant & 0xFFFFFFFFFFFF0000) == 0)
```

If there are no issues with this pull request, could you please apply the same fix to all of your Susie-plugins?